### PR TITLE
fix checking property on null in ActiveRecord

### DIFF
--- a/src/Base/DataMapper.php
+++ b/src/Base/DataMapper.php
@@ -40,7 +40,7 @@ class DataMapper extends Component {
     }
 
     public function isPropertySet($name) {
-        return $this->canGetProperty($name) && isset($this->dataSource->$name);
+        return $this->canGetProperty($name) || isset($this->dataSource->$name);
     }
 
     public function getDataSource() {


### PR DESCRIPTION
Here's the check `empty($user->phoneNumber)`.  User is entity, this check will return true, but it's not correct, because user table contains this column and has value.

`$this-canGetProperty($name)` will return false as it's not class's or behavior's attribute(this is what canGetProperty will check on), but it's attribute of ActiveRecord. Second check will return true, but whole expression gets false as the first argument of `&&` gets false.
