### PR TITLE
visibility changed from private to protected for property that can be…

### DIFF
--- a/src/DB/EntitiesRepository.php
+++ b/src/DB/EntitiesRepository.php
@@ -28,7 +28,7 @@ class EntitiesRepository extends Base\Repository {
      * @var string indicates what finder to use. By default equal following template "{model name}Finder" where model name is equal to
      * the repository class name without "Repository" suffix.
      */
-    private $_finderClassName;
+    protected $_finderClassName;
     /**
      * @var string entities finder class name. This class being used if no finder specified in morel directory. Change it
      * in {@link init()} method if you need custom default finder.


### PR DESCRIPTION
… redefined in parent classes

| Question      | Answer
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Specs pass?   | yes

I agree that $_defaultFinderClassName should be private, because it takes part in class logic. But developers should have ability to redefine Finder class if it's needed